### PR TITLE
add minecraft version 1.21.8 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     `maven-publish`
 }
 
-val baseVersion = "0.0.13"
+val baseVersion = "0.0.14"
 val commitHash = System.getenv("COMMIT_HASH")
 val timestamp = System.currentTimeMillis() // Temporary to be able to build and publish directly out of fix branch with same commit hash
 val snapshotVersion = "${baseVersion}-dev.${timestamp}-${commitHash}"

--- a/platform/bungeecord/build.gradle.kts
+++ b/platform/bungeecord/build.gradle.kts
@@ -53,6 +53,7 @@ modrinth {
         "1.21.5",
         "1.21.6",
         "1.21.7",
+        "1.21.8",
     )
     loaders.add("bungeecord")
     loaders.add("waterfall")

--- a/platform/spigot/build.gradle.kts
+++ b/platform/spigot/build.gradle.kts
@@ -56,6 +56,7 @@ modrinth {
         "1.21.5",
         "1.21.6",
         "1.21.7",
+        "1.21.8",
     )
     loaders.add("spigot")
     loaders.add("paper")

--- a/platform/velocity/build.gradle.kts
+++ b/platform/velocity/build.gradle.kts
@@ -56,6 +56,7 @@ modrinth {
         "1.21.5",
         "1.21.6",
         "1.21.7",
+        "1.21.8",
     )
     loaders.add("velocity")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported versions for the configuration across multiple build files by adding version `1.21.8`.

### Updates to supported versions:

* Added version `1.21.8` to the configuration in `platform/bungeecord/build.gradle.kts`.
* Added version `1.21.8` to the configuration in `platform/spigot/build.gradle.kts`.
* Added version `1.21.8` to the configuration in `platform/velocity/build.gradle.kts`.