### PR TITLE
fix(velocity): update import statement to use correct @Inject annotation

### DIFF
--- a/platform/velocity/src/main/kotlin/app/simplecloud/api/platform/velocity/VelocityApiProvider.kt
+++ b/platform/velocity/src/main/kotlin/app/simplecloud/api/platform/velocity/VelocityApiProvider.kt
@@ -2,12 +2,12 @@ package app.simplecloud.api.platform.velocity
 
 import app.simplecloud.api.platform.shared.PlayerSynchronizer
 import app.simplecloud.controller.api.ControllerApi
+import com.google.inject.Inject
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent
 import com.velocitypowered.api.proxy.ProxyServer
 import org.slf4j.Logger
-import javax.inject.Inject
 
 class VelocityApiProvider @Inject constructor(
     private val logger: Logger,


### PR DESCRIPTION
This pr fixes an issue where, when using [Velocity-CTD](https://github.com/GemstoneGG/Velocity-CTD), the plugin would not load and result in the proxy server not starting. While Velocity-CTD is not that widely used, the issue itself is easy to fix, and breaks nothing.

This issue is due to using the wrong `@Inject` annotation. (`javax.inject.Inject` instead of `com.google.inject.Inject`)
> You can see in the [velocity documentation](https://docs.papermc.io/velocity/dev/api-basics/) that the right annotation is the google one.

This pr is a one-liner: feel free to fix it yourself and not merge it. I have also tested this fix and made sure it works on my end.

Here is a picture of what happens when you run Velocity-CTD.
<img width="1920" height="951" alt="image of the issue" src="https://github.com/user-attachments/assets/04ccc3fd-746b-48d8-aed5-cbd4c41e8d70" />

Thank you!