### PR TITLE
Remove noisy presence compare info log

### DIFF
--- a/api/src/main/java/app/simplecloud/api/internal/integration/presence/ProxyPresenceResponder.java
+++ b/api/src/main/java/app/simplecloud/api/internal/integration/presence/ProxyPresenceResponder.java
@@ -96,11 +96,6 @@ public final class ProxyPresenceResponder {
             int localHash = computeHash(players);
             boolean match = localHash == request.getHash();
 
-            LOGGER.info("[Presence] Compare request received — controller hash: " + request.getHash()
-                    + ", local hash: " + localHash + ", match: " + match
-                    + ", online players (" + players.size() + "): "
-                    + players.stream().map(p -> p.getName() + "(" + p.getPlayerId() + ")").toList());
-
             ProxyPresenceCompareResponse.Builder response = ProxyPresenceCompareResponse.newBuilder()
                     .setMatch(match);
 


### PR DESCRIPTION
## Description

The proxy/controller presence reconciliation loop fires `handleCompareRequest` on every tick. Each invocation currently logs the controller hash, local hash, match result, **and the full online-player list** at `INFO` level. On a busy proxy this dominates log output and buries genuinely interesting operational events behind routine traffic.

Because the log is purely diagnostic and does not influence the compare/response outcome, removing it restores `INFO` as a useful signal level without changing any reconciliation behavior.

## Changes

- Removed the `LOGGER.info("[Presence] Compare request received …")` call (4 lines) from `ProxyPresenceResponder.handleCompareRequest`
- No other logic, imports, or formatting touched

## Type of Change
- [ ] New feature / capability
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Behavior Change

**Before:** Every presence compare request emits an `INFO` log line containing controller hash, local hash, match flag, and the full list of online player names + UUIDs.

**After:** The compare request completes silently on success. Warning-level logging for actual processing failures remains unchanged.

## Pre-Deployment Migrations

No migrations required before deploying.